### PR TITLE
changed requirements.txt and readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ link: [ModelScope-FlashFace](https://www.modelscope.cn/models/iic/FlashFace/summ
 
 link: [Huggingface-FlashFace](https://huggingface.co/shilongz/FlashFace-SD1.5)
 
-You should download all the related weights and put them in the `cache` folder.
+You should download all the related weights and put them in the `cache` folder (e.g. `FlashFace/cache/flashface.ckpt`).
 
 ## Demo
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ safetensors==0.3.3
 torch==2.1.0
 torchvision==0.16.0
 transformers==4.33.1
+easydict==1.13
+ftfy==6.2.0


### PR DESCRIPTION
There were two missing requirements that I had to install manually in the conda environment, easydict and ftfy. These were added to the requirements.txt.

The readme has been updated to add clarification on the location of the cache folder and how the files should appear in the structure.

