### PR TITLE
Fix path issue on Windows

### DIFF
--- a/ldm/data/tokenizers.py
+++ b/ldm/data/tokenizers.py
@@ -3,6 +3,7 @@
 import gzip
 import html
 from functools import lru_cache
+from pathlib import Path
 
 import ftfy
 import regex as re
@@ -78,8 +79,8 @@ class CLIPTokenizer(object):
         self.byte_decoder = {v: k for k, v in self.byte_encoder.items()}
 
         merges = gzip.open(
-            __file__.replace("ldm/data/tokenizers.py", "cache/bpe_simple_vocab_16e6.txt.gz")).read().decode(
-            'utf-8').split('\n')
+            Path(__file__).parents[2] / "cache" / "bpe_simple_vocab_16e6.txt.gz"
+        ).read().decode('utf-8').split('\n')
         merges = merges[1:49152 - 256 - 2 + 1]
         merges = [tuple(merge.split()) for merge in merges]
         vocab = list(bytes_to_unicode().values())

--- a/ldm/models/clip.py
+++ b/ldm/models/clip.py
@@ -1,6 +1,7 @@
 """Concise re-implementation of ``https://github.com/openai/CLIP'' and
 ``https://github.com/mlfoundations/open_clip''."""
 import math
+from pathlib import Path
 
 import torch
 import torch.nn as nn
@@ -503,10 +504,8 @@ def _clip(pretrained=False,
 
     # load checkpoint
     if pretrained and pretrained_name:
-
-        path = __file__.replace('ldm/models/clip.py',
-                                './cache/openai-clip-vit-large-14.pth')
-        assert pretrained_name in path
+        path = Path(__file__).parents[2] / "cache" / "openai-clip-vit-large-14.pth"
+        assert pretrained_name in str(path)
         # load
         model.load_state_dict(torch.load(path,
                                          map_location=device,

--- a/ldm/models/retinaface.py
+++ b/ldm/models/retinaface.py
@@ -2,6 +2,7 @@
 ``https://github.com/biubug6/Pytorch_Retinaface''."""
 import itertools
 import math
+from pathlib import Path
 
 import torch
 import torch.nn as nn
@@ -379,9 +380,7 @@ def retinaface(pretrained=False, device='cpu', backbone='resnet50'):
         # init a model on device
         with torch.device(device):
             model = RetinaFace(backbone=backbone)
-        ckpt_path = __file__.replace('ldm/models/retinaface.py',
-                                     f'./cache/retinaface_{backbone}.pth')
-        # load checkpoint
+        ckpt_path = Path(__file__).parents[2] / "cache" / f"retinaface_{backbone}.pth"
         model.load_state_dict(torch.load(ckpt_path, map_location=device))
     else:
         # init a model on device

--- a/ldm/models/vae.py
+++ b/ldm/models/vae.py
@@ -3,6 +3,7 @@
 ``https://github.com/CompVis/latent-diffusion'', and
 ``https://github.com/Stability-AI/generative-models''."""
 import math
+from pathlib import Path
 
 import torch
 import torch.nn as nn
@@ -283,7 +284,6 @@ def sd_v1_vae(pretrained=False, device='cpu', **kwargs):
     model = AutoencoderKL(**cfg).to(device)
     if pretrained:
         model.load_state_dict(
-            torch.load(__file__.replace('ldm/models/vae.py',
-                                        'cache/sd-v1-vae.pth'),
+            torch.load(Path(__file__).parents[2] / "cache" / "sd-v1-vae.pth",
                        map_location=device))
     return model


### PR DESCRIPTION
Closes https://github.com/ali-vilab/FlashFace/issues/4.

This PR fixes path issue on windows. On windows, path separator is `"\\"` instead of `"/"`. The target sequence in the replace function is not found, so no replace happens.
